### PR TITLE
Updated API for cloud Model, with Config & __call__

### DIFF
--- a/python/lsst/sims/cloudModel/__init__.py
+++ b/python/lsst/sims/cloudModel/__init__.py
@@ -2,4 +2,6 @@
 Module for classes dealing with environmental conditions.
 """
 from .version import *
+from .cloudData import *
 from .cloudModel import *
+from .cloudModelConfig import *

--- a/python/lsst/sims/cloudModel/cloudData.py
+++ b/python/lsst/sims/cloudModel/cloudData.py
@@ -93,3 +93,15 @@ class CloudData(object):
         self.min_time = self.cloud_dates[0]
         self.max_time = self.cloud_dates[-1]
         self.time_range = self.max_time - self.min_time
+
+    def config_info(self):
+        """Report information about configuration of this data.
+
+        Returns
+        -------
+        OrderedDict
+        """
+        config_info = OrderedDict()
+        config_info['Start time for db'] = self.start_time
+        config_info['Cloud database'] = self.cloud_db
+        return config_info

--- a/python/lsst/sims/cloudModel/cloudData.py
+++ b/python/lsst/sims/cloudModel/cloudData.py
@@ -36,6 +36,7 @@ class CloudData(object):
 
         self.cloud_dates = None
         self.cloud_values = None
+        self.read_data()
 
     def __call__(self, time):
         """Get the cloud for the specified time.
@@ -50,7 +51,7 @@ class CloudData(object):
         Returns
         -------
         float
-            The cloud (fraction of sky in 8ths) closest to the specified time.
+            The fraction of the sky that is cloudy (measured in steps of 8ths) closest to the specified time.
         """
         delta_time = (time - self.start_time).sec
         dbdate = delta_time % self.time_range + self.min_time
@@ -99,9 +100,9 @@ class CloudData(object):
 
         Returns
         -------
-        OrderedDict
+        Dict
         """
-        config_info = OrderedDict()
+        config_info = {}
         config_info['Start time for db'] = self.start_time
         config_info['Cloud database'] = self.cloud_db
         return config_info

--- a/python/lsst/sims/cloudModel/cloudData.py
+++ b/python/lsst/sims/cloudModel/cloudData.py
@@ -1,0 +1,89 @@
+from builtins import object
+from datetime import datetime
+import os
+import sqlite3
+import numpy as np
+from lsst.utils import getPackageDir
+
+__all__ = ["CloudData"]
+
+
+class CloudData(object):
+    """Handle the cloud information.
+
+    This class deals with the cloud information that was previously produced for
+    OpSim version 3.
+
+    Parameters
+    ----------
+    time_handler : :class:`lsst.sims.utils.TimeHandler`
+        The instance of the simulation time handler.
+    cloud_db : str, opt
+            The full path name for the cloud database. Default None,
+            which will use the database stored in the module ($SIMS_CLOUDMODEL_DIR/data/cloud.db).
+    """
+    def __init__(self, time_handler, cloud_db=None):
+        self.cloud_db = cloud_db
+        if self.cloud_db is None:
+            self.cloud_db = os.path.join(getPackageDir('sims_cloudModel'), 'data', 'cloud.db')
+
+        model_time_start = datetime(time_handler.initial_dt.year, 1, 1)
+        self.offset = time_handler.time_since_given_datetime(model_time_start,
+                                                             reverse=True)
+        self.cloud_dates = None
+        self.cloud_values = None
+
+    def __call__(self, delta_time):
+        """Get the cloud for the specified time.
+
+        Parameters
+        ----------
+        delta_time : int
+            The time (seconds) from the start of the simulation.
+
+        Returns
+        -------
+        float
+            The cloud (fraction of sky in 8ths) closest to the specified time.
+        """
+        delta_time += self.offset
+        date = delta_time % self.time_range + self.min_time
+        idx = np.searchsorted(self.cloud_dates, date)
+        # searchsorted ensures that left < date < right
+        # but we need to know if date is closer to left or to right
+        left = self.cloud_dates[idx - 1]
+        right = self.cloud_dates[idx]
+        if date - left < right - date:
+            idx -= 1
+        return self.cloud_values[idx]
+
+    def read_data(self):
+        """Read the cloud data from disk.
+
+        The default behavior is to use the module stored database. However, an
+        alternate database file can be provided. The alternate database file needs to have a
+        table called *Cloud* with the following columns:
+
+        cloudId
+            int : A unique index for each cloud entry.
+        c_date
+            int : The time (units=seconds) since the start of the simulation for the cloud observation.
+        cloud
+            float : The cloud coverage (in steps of 8ths) of the sky.
+        """
+        with sqlite3.connect(self.cloud_db) as conn:
+            cur = conn.cursor()
+            query = "select c_date, cloud from Cloud order by c_date;"
+            cur.execute(query)
+            results = np.array(cur.fetchall())
+            self.cloud_dates = np.hsplit(results, 2)[0].flatten()
+            self.cloud_values = np.hsplit(results, 2)[1].flatten()
+            cur.close()
+        # Make sure seeing dates are ordered appropriately (monotonically increasing).
+        ordidx = self.cloud_dates.argsort()
+        self.cloud_dates = self.cloud_dates[ordidx]
+        self.cloud_values = self.cloud_values[ordidx]
+        # Record this information, in case the cloud database does not start at t=0.
+        self.min_time = self.cloud_dates[0]
+        self.max_time = self.cloud_dates[-1]
+        self.time_range = self.max_time - self.min_time

--- a/python/lsst/sims/cloudModel/cloudModel.py
+++ b/python/lsst/sims/cloudModel/cloudModel.py
@@ -30,14 +30,14 @@ class CloudModel(object):
     processed telemetry values.
     """
     def __init__ (self, config=None):
-        self._configure(config=config)
+        self.configure(config=config)
         self.efd_requirements = (self._config.efd_columns, self._config.efd_delta_time)
         self.target_requirements = self._config.target_columns
         self.altcol = self.target_requirements[0]
         self.azcol = self.target_requirements[1]
         self.efd_cloud = self._config.efd_columns[0]
 
-    def _configure(self, config=None):
+    def configure(self, config=None):
         """Configure the model. After 'configure' the model config will be frozen.
 
         Parameters

--- a/python/lsst/sims/cloudModel/cloudModel.py
+++ b/python/lsst/sims/cloudModel/cloudModel.py
@@ -29,7 +29,7 @@ class CloudModel(object):
     This corresponds to the data columns required in the target map dictionary passed when calculating the
     processed telemetry values.
     """
-    def __init__ (self, config=None):
+    def __init__(self, config=None):
         self._configure(config=config)
         self.efd_requirements = (self._config.efd_columns, self._config.efd_delta_time)
         self.target_requirements = self._config.target_columns
@@ -69,7 +69,7 @@ class CloudModel(object):
             config_info[k] = v
         return config_info
 
-    def __call__(self, efdData, targetDict):
+    def __call__(self, cloud_value, altitude):
         """Calculate the sky coverage due to clouds.
 
         This is where we'd plug in Peter's cloud transparency maps and predictions.
@@ -79,19 +79,20 @@ class CloudModel(object):
 
         Parameters
         ----------
-        efdData: dict
-            Dictionary of input telemetry, typically from the EFD.
-            This must contain columns self.efd_requirements.
-            (work in progress on handling time history).
-        targetDict: dict
-            Dictionary of target map values over which to calculate the processed telemetry.
-            (e.g. targetDict = {'ra': [], 'dec': [], 'altitude': [], 'azimuth': [], 'airmass': []})
-            Here we use 'altitude' and 'azimuth', which should be numpy arrays .
+        cloud_value: float or efdData dict
+            The value to give the clouds (XXX-units?).
+        altitude:  float, np.array, or targetDict
+            Altitude of the output (arbitrary).
 
         Returns
         -------
         dict of np.ndarray
             Cloud transparency map values.
         """
-        model_cloud = np.zeros(len(targetDict[self.altcol]), float) + efdData[self.efd_cloud]
+        if isinstance(cloud_value, dict):
+            cloud_value = cloud_value[self.efd_cloud]
+        if isinstance(altitude, dict):
+            altitude = altitude[self.altcol]
+
+        model_cloud = np.zeros(len(altitude), float) + cloud_value
         return {'cloud': model_cloud}

--- a/python/lsst/sims/cloudModel/cloudModel.py
+++ b/python/lsst/sims/cloudModel/cloudModel.py
@@ -1,92 +1,98 @@
 from builtins import object
-from datetime import datetime
-import os
-import sqlite3
+from collections import OrderedDict
 import numpy as np
-from lsst.utils import getPackageDir
+from .cloudModelConfig import CloudModelConfig
+from lsst.sims.cloudModel import version
+
 
 __all__ = ["CloudModel"]
 
 
 class CloudModel(object):
-    """Handle the cloud information.
+    """LSST cloud calculations for cloud extinction.
+    Currently this actually only returns the cloud coverage of the sky, exactly as reported in the
+    cloud database (thus the sky coverage, in fractions of 8ths).
 
-    This class deals with the cloud information that was previously produced for
-    OpSim version 3.
 
     Parameters
     ----------
-    time_handler : :class:`lsst.sims.utils.TimeHandler`
-        The instance of the simulation time handler.
-    """
-    def __init__(self, time_handler):
-        self.cloud_db = None
-        model_time_start = datetime(time_handler.initial_dt.year, 1, 1)
-        self.offset = time_handler.time_since_given_datetime(model_time_start,
-                                                             reverse=True)
-        self.cloud_dates = None
-        self.cloud_values = None
+    config: CloudModelConfig, opt
+        A configuration class for the cloud model.
+        This can be None, in which case the default CloudModelConfig is used.
+        The user should set any non-default values for CloudModelConfig before
+        configuration of the actual CloudModel.
 
-    def get_cloud(self, delta_time):
-        """Get the cloud for the specified time.
+    self.efd_requirements and self.map_requirements are also set.
+    efd_requirements is a tuple: (list of str, float).
+    This corresponds to the data columns required from the EFD and the amount of time history required.
+    map_requirements is a list of str.
+    This corresponds to the data columns required in the map dictionary passed when calculating the
+    processed telemetry values.
+    """
+    def __init__ (self, config=None):
+        self._configure(config=config)
+        self.efd_requirements = (self._config.efd_columns, self._config.efd_delta_time)
+        self.map_requirements = ['altitude', 'azimuth']
+        self.altcol = self.map_requirements[0]
+        self.azcol = self.map_requirements[1]
+        self.cloudcol = self._config.efd_columns[0]
+
+    def _configure(self, config=None):
+        """Configure the model. After 'configure' the model config will be frozen.
 
         Parameters
         ----------
-        delta_time : int
-            The time (seconds) from the start of the simulation.
+        config: CloudModelConfig, opt
+            A configuration class for the cloud model.
+            This can be None, in which case the default values are used.
+        """
+        if config is None:
+            self._config = CloudModelConfig()
+        else:
+            if not isinstance(config, CloudModelConfig):
+                raise ValueError('Must use a CloudModelConfig.')
+            self._config = config
+        self._config.validate()
+        self._config.freeze()
+
+    def status(self):
+        """Report configuration parameters and version information.
 
         Returns
         -------
-        float
-            The cloud (fraction of sky in 8ths) closest to the specified time.
+        OrderedDict
         """
-        delta_time += self.offset
-        date = delta_time % self.time_range + self.min_time
-        idx = np.searchsorted(self.cloud_dates, date)
-        # searchsorted ensures that left < date < right
-        # but we need to know if date is closer to left or to right
-        left = self.cloud_dates[idx - 1]
-        right = self.cloud_dates[idx]
-        if date - left < right - date:
-            idx -= 1
-        return self.cloud_values[idx]
+        status = OrderedDict()
+        status['CloudModel_version'] = '%s' % version.__version__
+        status['CloudModel_sha'] = '%s' % version.__fingerprint__
+        for k, v in self._config.iteritems():
+            status[k] = v
+        status['map_columns'] = self.map_requirements
+        return status
 
-    def read_data(self, cloud_db=None):
-        """Read the cloud data from disk.
+    def __call__(self, efdData, mapDict):
+        """Calculate the sky coverage due to clouds.
 
-        The default behavior is to use the module stored database. However, an
-        alternate database file can be provided. The alternate database file needs to have a
-        table called *Cloud* with the following columns:
-
-        cloudId
-            int : A unique index for each cloud entry.
-        c_date
-            int : The time (units=seconds) since the start of the simulation for the cloud observation.
-        cloud
-            float : The cloud coverage in 8ths of the sky.
+        This is where we'd plug in Peter's cloud transparency maps and predictions.
+        We could also try translating cloud transparency into a cloud extinction.
+        For now, we're simply returning the cloud coverage that we already got from the database,
+        but multiplied over the whole sky to provide a map.
 
         Parameters
         ----------
-        cloud_db : str, opt
-            The full path name for the cloud database. Default None,
-            which will use the database stored in the module ($SIMS_CLOUDMODEL_DIR/data/cloud.db).
+        efdData: dict
+            Dictionary of input telemetry, typically from the EFD.
+            This must contain columns self.efd_requirements.
+            (work in progress on handling time history).
+        mapDict: dict
+            Dictionary of map values over which to calculate the processed telemetry.
+            (e.g. mapDict = {'ra': [], 'dec': [], 'altitude': [], 'azimuth': [], 'airmass': []})
+            Here we use 'altitude' and 'azimuth', which should be a numpy array.
+
+        Returns
+        -------
+        np.ndarray
+            Cloud transparency map values.
         """
-        self.cloud_db = cloud_db
-        if self.cloud_db is None or self.cloud_db is "":
-            self.cloud_db = os.path.join(getPackageDir('sims_cloudModel'), 'data', 'cloud.db')
-        with sqlite3.connect(self.cloud_db) as conn:
-            cur = conn.cursor()
-            query = "select c_date, cloud from Cloud order by c_date;"
-            cur.execute(query)
-            results = np.array(cur.fetchall())
-            self.cloud_dates = np.hsplit(results, 2)[0].flatten()
-            self.cloud_values = np.hsplit(results, 2)[1].flatten()
-            cur.close()
-        # Make sure seeing dates are ordered appropriately (monotonically increasing).
-        ordidx = self.cloud_dates.argsort()
-        self.cloud_dates = self.cloud_dates[ordidx]
-        self.cloud_values = self.cloud_values[ordidx]
-        # Record this information, in case the cloud database does not start at t=0.
-        self.min_time = self.cloud_dates[0]
-        self.max_time = self.cloud_dates[-1]
-        self.time_range = self.max_time - self.min_time
+        cloud = np.zeros(len(mapDict[self.altcol]), float) + efdData[self.cloudcol]
+        return cloud

--- a/python/lsst/sims/cloudModel/cloudModel.py
+++ b/python/lsst/sims/cloudModel/cloudModel.py
@@ -25,8 +25,8 @@ class CloudModel(object):
     self.efd_requirements and self.map_requirements are also set.
     efd_requirements is a tuple: (list of str, float).
     This corresponds to the data columns required from the EFD and the amount of time history required.
-    map_requirements is a list of str.
-    This corresponds to the data columns required in the map dictionary passed when calculating the
+    target_requirements is a list of str.
+    This corresponds to the data columns required in the target map dictionary passed when calculating the
     processed telemetry values.
     """
     def __init__ (self, config=None):
@@ -36,7 +36,6 @@ class CloudModel(object):
         self.altcol = self.target_requirements[0]
         self.azcol = self.target_requirements[1]
         self.efd_cloud = self._config.efd_columns[0]
-        self.model_cloud = self._config.model_keys[0]
 
     def _configure(self, config=None):
         """Configure the model. After 'configure' the model config will be frozen.
@@ -95,4 +94,4 @@ class CloudModel(object):
             Cloud transparency map values.
         """
         model_cloud = np.zeros(len(targetDict[self.altcol]), float) + efdData[self.efd_cloud]
-        return {self.model_cloud: model_cloud}
+        return {'cloud': model_cloud}

--- a/python/lsst/sims/cloudModel/cloudModel.py
+++ b/python/lsst/sims/cloudModel/cloudModel.py
@@ -30,7 +30,7 @@ class CloudModel(object):
     processed telemetry values.
     """
     def __init__(self, config=None):
-        self._configure(config=config)
+        self.configure(config=config)
         self.efd_requirements = (self._config.efd_columns, self._config.efd_delta_time)
         self.target_requirements = self._config.target_columns
         self.altcol = self.target_requirements[0]

--- a/python/lsst/sims/cloudModel/cloudModelConfig.py
+++ b/python/lsst/sims/cloudModel/cloudModelConfig.py
@@ -1,0 +1,15 @@
+import lsst.pex.config as pexConfig
+
+
+__all__ = ['CloudModelConfig']
+
+
+class CloudModelConfig(pexConfig.Config):
+    """A pex_config configuration class for default seeing model parameters.
+    """
+    efd_columns = pexConfig.ListField(doc="List of data required from EFD",
+                                      dtype=str,
+                                      default=['cloud'])
+    efd_delta_time = pexConfig.Field(doc="Length (delta time) of history to request from the EFD (seconds)",
+                                     dtype=float,
+                                     default=0)

--- a/python/lsst/sims/cloudModel/cloudModelConfig.py
+++ b/python/lsst/sims/cloudModel/cloudModelConfig.py
@@ -13,9 +13,7 @@ class CloudModelConfig(pexConfig.Config):
     efd_delta_time = pexConfig.Field(doc="Length (delta time) of history to request from the EFD (seconds)",
                                      dtype=float,
                                      default=0)
-    target_columns = pexConfig.ListField(doc="List of columns required from Scheduler target maps",
+    target_columns = pexConfig.ListField(doc="Names of the keys for (altitude, azimuth) from the "
+                                             "scheduler target maps",
                                          dtype=str,
                                          default=['altitude', 'azimuth'])
-    model_keys = pexConfig.ListField(doc="List of keys referring to the data returned from the model",
-                                     dtype=str,
-                                     default=['cloud'])

--- a/python/lsst/sims/cloudModel/cloudModelConfig.py
+++ b/python/lsst/sims/cloudModel/cloudModelConfig.py
@@ -13,3 +13,9 @@ class CloudModelConfig(pexConfig.Config):
     efd_delta_time = pexConfig.Field(doc="Length (delta time) of history to request from the EFD (seconds)",
                                      dtype=float,
                                      default=0)
+    target_columns = pexConfig.ListField(doc="List of columns required from Scheduler target maps",
+                                         dtype=str,
+                                         default=['altitude', 'azimuth'])
+    model_keys = pexConfig.ListField(doc="List of keys referring to the data returned from the model",
+                                     dtype=str,
+                                     default=['cloud'])

--- a/tests/test_cloudData.py
+++ b/tests/test_cloudData.py
@@ -17,8 +17,6 @@ class TestCloudModel(unittest.TestCase):
 
     def test_basic_information_after_creation(self):
         cloudData = CloudData(self.th, cloud_db=self.cloud_db)
-        self.assertIsNone(cloudData.cloud_dates)
-        self.assertIsNone(cloudData.cloud_values)
         self.assertEqual(cloudData.start_time, self.th)
         cloudData = CloudData(self.th, cloud_db=self.cloud_db, offset_year = 1)
         self.assertEqual(cloudData.start_time, Time('2021-01-01', format='isot', scale='tai'))

--- a/tests/test_cloudData.py
+++ b/tests/test_cloudData.py
@@ -1,29 +1,31 @@
 import os
 import sqlite3
 import unittest
+from astropy.time import Time, TimeDelta
 from lsst.utils import getPackageDir
 import lsst.utils.tests
 from lsst.utils.tests import getTempFilePath
 
 from lsst.sims.cloudModel import CloudData
-from lsst.sims.utils import TimeHandler
 
 class TestCloudModel(unittest.TestCase):
 
     def setUp(self):
-        self.th = TimeHandler("2020-01-01")
+        self.th = Time('2020-01-01', format='isot', scale='tai')
         self.cloud_db = os.path.join(getPackageDir('sims_cloudModel'), 'data', 'cloud.db')
         self.num_original_values = 29201
 
     def test_basic_information_after_creation(self):
-        cloudData = CloudData(self.th, self.cloud_db)
+        cloudData = CloudData(self.th, cloud_db=self.cloud_db)
         self.assertIsNone(cloudData.cloud_dates)
         self.assertIsNone(cloudData.cloud_values)
-        self.assertEqual(cloudData.offset, 0)
+        self.assertEqual(cloudData.start_time, self.th)
+        cloudData = CloudData(self.th, cloud_db=self.cloud_db, offset_year = 1)
+        self.assertEqual(cloudData.start_time, Time('2021-01-01', format='isot', scale='tai'))
 
     def test_information_after_initialization(self):
         # Test setting cloud_db explicitly.
-        cloudData = CloudData(self.th, self.cloud_db)
+        cloudData = CloudData(self.th, cloud_db=self.cloud_db)
         cloudData.read_data()
         self.assertEqual(cloudData.cloud_values.size, self.num_original_values)
         self.assertEqual(cloudData.cloud_dates.size, self.num_original_values)
@@ -33,21 +35,27 @@ class TestCloudModel(unittest.TestCase):
         self.assertEqual(cloudData.cloud_dates.size, self.num_original_values)
 
     def test_get_clouds(self):
-        cloudData = CloudData(self.th, self.cloud_db)
+        cloudData = CloudData(self.th, cloud_db=self.cloud_db)
         cloudData.read_data()
-        self.assertEqual(cloudData(700000), 0.5)
-        self.assertEqual(cloudData(701500), 0.5)
-        self.assertEqual(cloudData(705000), 0.375)
-        self.assertEqual(cloudData(630684000), 0.0)
+        dt = TimeDelta(700000, format='sec')
+        self.assertEqual(cloudData(self.th + dt), 0.5)
+        dt = TimeDelta(701500, format='sec')
+        self.assertEqual(cloudData(self.th + dt), 0.5)
+        dt = TimeDelta(705000, format='sec')
+        self.assertEqual(cloudData(self.th + dt), 0.375)
+        dt = TimeDelta(630684000, format='sec')
+        self.assertEqual(cloudData(self.th + dt), 0.0)
 
     def test_get_clouds_using_different_start_month(self):
-        cloud1 = CloudData(TimeHandler("2020-05-24"))
-        self.assertEqual(cloud1.offset, 12441600)
+        # Just changing the starting month
+        t2 = Time('2020-05-24', format='isot', scale='tai')
+        cloud1 = CloudData(t2)
+        self.assertEqual(cloud1.start_time, self.th)
         cloud1.read_data()
-        self.assertEqual(cloud1(700000), 0.0)
-        self.assertEqual(cloud1(701500), 0.0)
-        self.assertEqual(cloud1(705000), 0.0)
-        self.assertEqual(cloud1(630684000), 0.25)
+        dt = TimeDelta(700000, format='sec')
+        self.assertEqual(cloud1(t2 + dt), 0.0)
+        dt = TimeDelta(630684000, format='sec')
+        self.assertEqual(cloud1(t2 + dt), 0.25)
 
     def test_alternate_db(self):
         with getTempFilePath('.alt_cloud.db') as tmpdb:
@@ -62,7 +70,7 @@ class TestCloudModel(unittest.TestCase):
                 cur.execute("CREATE TABLE Cloud({})".format(",".join(cloud_table)))
                 cur.executemany("INSERT INTO Cloud VALUES(?, ?, ?)", [(1, 9997, 0.5), (2, 10342, 0.125)])
                 cur.close()
-            cloud1 = CloudData(TimeHandler("2020-01-01"), tmpdb)
+            cloud1 = CloudData(self.th, tmpdb)
             cloud1.read_data()
             self.assertEqual(cloud1.cloud_values.size, 2)
             self.assertEqual(cloud1.cloud_values[1], 0.125)

--- a/tests/test_cloudData.py
+++ b/tests/test_cloudData.py
@@ -5,7 +5,7 @@ from lsst.utils import getPackageDir
 import lsst.utils.tests
 from lsst.utils.tests import getTempFilePath
 
-from lsst.sims.cloudModel import CloudModel
+from lsst.sims.cloudModel import CloudData
 from lsst.sims.utils import TimeHandler
 
 class TestCloudModel(unittest.TestCase):
@@ -13,41 +13,41 @@ class TestCloudModel(unittest.TestCase):
     def setUp(self):
         self.th = TimeHandler("2020-01-01")
         self.cloud_db = os.path.join(getPackageDir('sims_cloudModel'), 'data', 'cloud.db')
-        self.cloud = CloudModel(self.th)
         self.num_original_values = 29201
 
     def test_basic_information_after_creation(self):
-        cloud = CloudModel(self.th)
-        self.assertIsNone(cloud.cloud_db)
-        self.assertIsNone(cloud.cloud_dates)
-        self.assertIsNone(cloud.cloud_values)
-        self.assertEqual(cloud.offset, 0)
+        cloudData = CloudData(self.th, self.cloud_db)
+        self.assertIsNone(cloudData.cloud_dates)
+        self.assertIsNone(cloudData.cloud_values)
+        self.assertEqual(cloudData.offset, 0)
 
     def test_information_after_initialization(self):
         # Test setting cloud_db explicitly.
-        self.cloud.read_data(self.cloud_db)
-        self.assertEqual(self.cloud.cloud_values.size, self.num_original_values)
-        self.assertEqual(self.cloud.cloud_dates.size, self.num_original_values)
-        # Test that find built-in module.
-        cloud = CloudModel(self.th)
-        cloud.read_data()
-        self.assertEqual(self.cloud.cloud_dates.size, self.num_original_values)
+        cloudData = CloudData(self.th, self.cloud_db)
+        cloudData.read_data()
+        self.assertEqual(cloudData.cloud_values.size, self.num_original_values)
+        self.assertEqual(cloudData.cloud_dates.size, self.num_original_values)
+        # Test that find built-in module automatically.
+        cloudData = CloudData(self.th)
+        cloudData.read_data()
+        self.assertEqual(cloudData.cloud_dates.size, self.num_original_values)
 
     def test_get_clouds(self):
-        self.cloud.read_data(self.cloud_db)
-        self.assertEqual(self.cloud.get_cloud(700000), 0.5)
-        self.assertEqual(self.cloud.get_cloud(701500), 0.5)
-        self.assertEqual(self.cloud.get_cloud(705000), 0.375)
-        self.assertEqual(self.cloud.get_cloud(630684000), 0.0)
+        cloudData = CloudData(self.th, self.cloud_db)
+        cloudData.read_data()
+        self.assertEqual(cloudData(700000), 0.5)
+        self.assertEqual(cloudData(701500), 0.5)
+        self.assertEqual(cloudData(705000), 0.375)
+        self.assertEqual(cloudData(630684000), 0.0)
 
     def test_get_clouds_using_different_start_month(self):
-        cloud1 = CloudModel(TimeHandler("2020-05-24"))
+        cloud1 = CloudData(TimeHandler("2020-05-24"))
         self.assertEqual(cloud1.offset, 12441600)
-        cloud1.read_data(self.cloud_db)
-        self.assertEqual(cloud1.get_cloud(700000), 0.0)
-        self.assertEqual(cloud1.get_cloud(701500), 0.0)
-        self.assertEqual(cloud1.get_cloud(705000), 0.0)
-        self.assertEqual(cloud1.get_cloud(630684000), 0.25)
+        cloud1.read_data()
+        self.assertEqual(cloud1(700000), 0.0)
+        self.assertEqual(cloud1(701500), 0.0)
+        self.assertEqual(cloud1(705000), 0.0)
+        self.assertEqual(cloud1(630684000), 0.25)
 
     def test_alternate_db(self):
         with getTempFilePath('.alt_cloud.db') as tmpdb:
@@ -62,8 +62,8 @@ class TestCloudModel(unittest.TestCase):
                 cur.execute("CREATE TABLE Cloud({})".format(",".join(cloud_table)))
                 cur.executemany("INSERT INTO Cloud VALUES(?, ?, ?)", [(1, 9997, 0.5), (2, 10342, 0.125)])
                 cur.close()
-            cloud1 = CloudModel(TimeHandler("2020-01-01"))
-            cloud1.read_data(cloud_db=tmpdb)
+            cloud1 = CloudData(TimeHandler("2020-01-01"), tmpdb)
+            cloud1.read_data()
             self.assertEqual(cloud1.cloud_values.size, 2)
             self.assertEqual(cloud1.cloud_values[1], 0.125)
 

--- a/tests/test_cloudModel.py
+++ b/tests/test_cloudModel.py
@@ -11,7 +11,6 @@ class TestCloudModel(unittest.TestCase):
         config.efd_columns = ['cloud']
         config.efd_delta_time = 30
         config.target_columns = ['altitude', 'azimuth']
-        config.model_keys = ['cloud']
         self.config = config
 
     def test_configure(self):
@@ -29,7 +28,7 @@ class TestCloudModel(unittest.TestCase):
         cloudModel = CloudModel()
         confDict = cloudModel.config_info()
         expected_keys = ['CloudModel_version', 'CloudModel_sha', 'efd_columns', 'efd_delta_time',
-                         'target_columns', 'model_keys']
+                         'target_columns']
         for k in expected_keys:
             self.assertTrue(k in confDict.keys())
 
@@ -39,6 +38,10 @@ class TestCloudModel(unittest.TestCase):
         self.assertEqual(self.config.efd_columns, cols)
         self.assertEqual(self.config.efd_delta_time, deltaT)
 
+    def test_targetmap_requirements(self):
+        cloudModel = CloudModel(self.config)
+        self.assertEqual(cloudModel.target_requirements, self.config.target_columns)
+
     def test_call(self):
         cloudModel = CloudModel(self.config)
         in_cloud = 1.53
@@ -46,11 +49,8 @@ class TestCloudModel(unittest.TestCase):
         alt = np.zeros(50, float)
         az = np.zeros(50, float)
         targetDict = {'altitude': alt, 'azimuth': az}
-        modelData = cloudModel(efdData, targetDict)
-        for k in self.config.model_keys:
-            self.assertTrue(k in modelData)
+        out_cloud = cloudModel(efdData, targetDict)['cloud']
         # Test that we propagated cloud value over the whole sky.
-        out_cloud = modelData['cloud']
         self.assertEqual(in_cloud, out_cloud.max())
         self.assertEqual(in_cloud, out_cloud.min())
         self.assertEqual(len(out_cloud), len(alt))

--- a/tests/test_cloudModel.py
+++ b/tests/test_cloudModel.py
@@ -1,0 +1,62 @@
+import numpy as np
+import unittest
+import lsst.utils.tests
+from lsst.sims.cloudModel import CloudModel, CloudModelConfig
+
+
+class TestCloudModel(unittest.TestCase):
+    def setUp(self):
+        # Set config to known values.
+        config = CloudModelConfig()
+        config.efd_columns = ['cloud']
+        config.efd_delta_time = 30
+        self.config = config
+
+    def test_configure(self):
+        # Configure with defaults.
+        cloudModel = CloudModel()
+        conf = CloudModelConfig()
+        self.assertEqual(cloudModel._config, conf)
+        # Test specifying the config.
+        cloudModel = CloudModel(self.config)
+        self.assertEqual(cloudModel._config.efd_delta_time, self.config.efd_delta_time)
+        # Test specifying an incorrect config.
+        self.assertRaises(ValueError, CloudModel, 0.8)
+
+    def test_status(self):
+        cloudModel = CloudModel()
+        confDict = cloudModel.status()
+        expected_keys = ['CloudModel_version', 'CloudModel_sha', 'efd_columns', 'efd_delta_time',
+                         'map_columns']
+        for k in expected_keys:
+            self.assertTrue(k in confDict.keys())
+
+    def test_efd_requirements(self):
+        cloudModel = CloudModel(self.config)
+        cols, deltaT = cloudModel.efd_requirements
+        self.assertEqual(self.config.efd_columns, cols)
+        self.assertEqual(self.config.efd_delta_time, deltaT)
+
+    def test_call(self):
+        cloudModel = CloudModel(self.config)
+        in_cloud = 1.53
+        efdData = {'cloud': in_cloud}
+        alt = np.zeros(50, float)
+        az = np.zeros(50, float)
+        mapDict = {'altitude': alt, 'azimuth': az}
+        out_cloud = cloudModel(efdData, mapDict)
+        # Test that we propagated cloud value over the whole sky.
+        self.assertEqual(in_cloud, out_cloud.max())
+        self.assertEqual(in_cloud, out_cloud.min())
+        self.assertEqual(len(out_cloud), len(alt))
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_cloudModel.py
+++ b/tests/test_cloudModel.py
@@ -10,6 +10,8 @@ class TestCloudModel(unittest.TestCase):
         config = CloudModelConfig()
         config.efd_columns = ['cloud']
         config.efd_delta_time = 30
+        config.target_columns = ['altitude', 'azimuth']
+        config.model_keys = ['cloud']
         self.config = config
 
     def test_configure(self):
@@ -25,9 +27,9 @@ class TestCloudModel(unittest.TestCase):
 
     def test_status(self):
         cloudModel = CloudModel()
-        confDict = cloudModel.status()
+        confDict = cloudModel.config_info()
         expected_keys = ['CloudModel_version', 'CloudModel_sha', 'efd_columns', 'efd_delta_time',
-                         'map_columns']
+                         'target_columns', 'model_keys']
         for k in expected_keys:
             self.assertTrue(k in confDict.keys())
 
@@ -43,9 +45,12 @@ class TestCloudModel(unittest.TestCase):
         efdData = {'cloud': in_cloud}
         alt = np.zeros(50, float)
         az = np.zeros(50, float)
-        mapDict = {'altitude': alt, 'azimuth': az}
-        out_cloud = cloudModel(efdData, mapDict)
+        targetDict = {'altitude': alt, 'azimuth': az}
+        modelData = cloudModel(efdData, targetDict)
+        for k in self.config.model_keys:
+            self.assertTrue(k in modelData)
         # Test that we propagated cloud value over the whole sky.
+        out_cloud = modelData['cloud']
         self.assertEqual(in_cloud, out_cloud.max())
         self.assertEqual(in_cloud, out_cloud.min())
         self.assertEqual(len(out_cloud), len(alt))

--- a/ups/sims_cloudModel.table
+++ b/ups/sims_cloudModel.table
@@ -1,4 +1,5 @@
 setupRequired(utils)
+setupRequired(pex_config)
 setupOptional(sims_utils)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
Configuration now done via a new pexConfig.Config config class (SeeingModelConfig).
Standardized API of the model by adding
self.efd_requirements
self.map_requirements
to specify columns required in dictionaries passed to call method (which calls the method to calculate the processed telemetry).

See https://github.com/rhiannonlynne/notebooks/blob/master/CloudModel%20Demo.ipynb for a notebook demo!